### PR TITLE
feat: add basic error element to leaflet overlay

### DIFF
--- a/public/leaflet.html
+++ b/public/leaflet.html
@@ -11,8 +11,25 @@
   <script src="https://unpkg.com/@rtirl/api@latest/lib/index.min.js"></script>
 </head>
 
+<style>
+.alert {
+  display: none;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  width: 300px;
+  background-color: #f44336;
+  color: white;
+  z-index: 401
+}
+</style>
+
 <body>
-  <div style="position: relative; width: 100%; height: 100%;">
+  
+  <div style="position: relative">
+    <div id="alert-box" class="alert"></div>
     <div id="map" style="width: 300px; height: 250px"></div>
     <div id="marker" style="
           background-color: cyan;
@@ -28,23 +45,26 @@
   </div>
   <script>
     var params = new URLSearchParams(window.location.search);
-      if(params.get("fullscreen")) {
+    if(params.get("fullscreen")) {
         document.documentElement.setAttribute('style', 'margin: 0; padding: 0; width: 100%; height: 100%;');
         document.body.setAttribute('style', 'margin: 0; padding: 0; width: 100%; height: 100%;');
         document.getElementById('map').setAttribute('style', 'height: 100%; width: 100%;');
         document.getElementById('marker').style.top = 'calc(50% - 6px)';
         document.getElementById('marker').style.left = 'calc(50% - 6px)';
-      }
+    }
     var zoom = params.get("zoom");
     var map = L.map("map").setView([0, 0], zoom ? Number(zoom) : 13);
-    L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+    var layer = L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
       accessToken: params.get("access_token"),
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> © <a href="https://www.mapbox.com/">Mapbox</a>',
       id: params.get("style"),
       tileSize: 512,
       zoomOffset: -1,
       zoom: zoom ? Number(zoom) : 13,
-    }).addTo(map);
+    });
+    layer.addTo(map);
+
+    layer.on('tileerror', handleTileError);
 
     // Setting this through options does not seem to work
     map.removeControl(map.zoomControl);
@@ -58,6 +78,23 @@
         });
       }
     );
+
+    function handleTileError(error, tile) {
+      displayError("Error loading tile: Check your access token and map style.");
+      console.log(error);
+    }
+
+    function displayError(errorMessage) {
+      var x = document.getElementById("alert-box");
+      x.style.display = "block";
+      x.innerText = errorMessage;
+      setTimeout(hideError, 30000);
+    }
+
+    function hideError() {
+      var x = document.getElementById("alert-box");
+      x.style.display = "none";
+    }
   </script>
 </body>
 


### PR DESCRIPTION
Added a very basic element for tile errors, let me know if that is nice enough.

![image](https://user-images.githubusercontent.com/994594/148870347-849f9016-76b9-4ade-8e1f-93c77e6a75c7.png)
