### PR TITLE
feat: add zoom slider

### DIFF
--- a/web-editor/src/component/MapboxMapContainer.jsx
+++ b/web-editor/src/component/MapboxMapContainer.jsx
@@ -22,7 +22,7 @@ export const MapboxMapContainer = ({
           styleDiffing
           width="100%"
           height="100%"
-          onDrag={(evt) =>
+          onMove={(evt) =>
             setViewState({
               latitude: evt.viewState.latitude,
               longitude: evt.viewState.longitude,

--- a/web-editor/src/component/MapboxMapContainer.jsx
+++ b/web-editor/src/component/MapboxMapContainer.jsx
@@ -8,17 +8,26 @@ export const MapboxMapContainer = ({
   setViewState,
   apiKey,
   canPreview,
+  zoom,
+  setZoom,
 }) => {
   return (
     <div style={{ height: "70vh", width: "85vw" }}>
       {canPreview ? (
         <MapGL
+          zoom={zoom}
+          onZoom={(evt) => setZoom(evt.viewState.zoom)}
           {...viewState}
           mapStyle={mapStyle}
           styleDiffing
           width="100%"
           height="100%"
-          onMove={(evt) => setViewState(evt.viewState)}
+          onDrag={(evt) =>
+            setViewState({
+              latitude: evt.viewState.latitude,
+              longitude: evt.viewState.longitude,
+            })
+          }
           mapboxAccessToken={apiKey}
         />
       ) : (

--- a/web-editor/src/component/RightPanel.jsx
+++ b/web-editor/src/component/RightPanel.jsx
@@ -17,11 +17,12 @@ export const RightPanel = ({
   mapProvider,
   googleStyleJSON,
   googleApiKey,
+  zoom,
+  setZoom
 }) => {
   const [viewState, setViewState] = useState({
     longitude: -100,
     latitude: 40,
-    zoom: 3,
   });
 
   const [canPreview, setCanPreview] = useState(true);
@@ -64,6 +65,8 @@ export const RightPanel = ({
         <MapboxMapContainer
           canPreview={canPreview}
           viewState={viewState}
+          zoom={zoom}
+          setZoom={setZoom}
           setViewState={setViewState}
           mapStyle={mapStyle}
           apiKey={apiKey}
@@ -73,7 +76,7 @@ export const RightPanel = ({
       )}
 
       {mapProvider === "mapbox"
-        ? `Longitude: ${viewState.longitude}, Latitude: ${viewState.latitude}, zoom: ${viewState.zoom}`
+        ? `Longitude: ${viewState.longitude}, Latitude: ${viewState.latitude}, zoom: ${zoom}`
         : ""}
       {/* <ExportPanel></ExportPanel> */}
       <ConsolePanel
@@ -82,7 +85,7 @@ export const RightPanel = ({
         googleStyleJSON={googleStyleJSON}
         canPreview={canPreview}
         lang={lang}
-        zoom={viewState.zoom}
+        zoom={zoom}
         styleID={styleID}
         pullKey={pullKey}
         apiKey={apiKey}

--- a/web-editor/src/component/RightPanel.jsx
+++ b/web-editor/src/component/RightPanel.jsx
@@ -18,7 +18,7 @@ export const RightPanel = ({
   googleStyleJSON,
   googleApiKey,
   zoom,
-  setZoom
+  setZoom,
 }) => {
   const [viewState, setViewState] = useState({
     longitude: -100,

--- a/web-editor/src/component/Settings.jsx
+++ b/web-editor/src/component/Settings.jsx
@@ -1,14 +1,11 @@
 import CodeIcon from "@mui/icons-material/Code";
 import KeyIcon from "@mui/icons-material/Key";
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
-import SearchIcon from "@mui/icons-material/Search";
 import StyleIcon from "@mui/icons-material/Style";
 import {
   IconButton,
   InputAdornment,
-  Link,
-  Slider,
-  Tooltip,
+  Link
 } from "@mui/material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";

--- a/web-editor/src/component/Settings.jsx
+++ b/web-editor/src/component/Settings.jsx
@@ -1,8 +1,15 @@
 import CodeIcon from "@mui/icons-material/Code";
 import KeyIcon from "@mui/icons-material/Key";
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
+import SearchIcon from "@mui/icons-material/Search";
 import StyleIcon from "@mui/icons-material/Style";
-import { IconButton, InputAdornment, Link } from "@mui/material";
+import {
+  IconButton,
+  InputAdornment,
+  Link,
+  Slider,
+  Tooltip,
+} from "@mui/material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
@@ -12,6 +19,7 @@ import Typography from "@mui/material/Typography";
 import { useEffect, useState } from "react";
 import ControlPanel from "./ControlPanel";
 import { StyleIDHelperDialog } from "./StyleIDHelperDialog";
+import { ZoomSlider } from "./ZoomSlider";
 
 export const Settings = ({
   onStyleJSONSubmit,
@@ -21,6 +29,8 @@ export const Settings = ({
   mapStyle,
   setMapStyle,
   mapProvider,
+  zoom,
+  setZoom,
 }) => {
   const [openStyleIDDialog, setOpenStyleIDDialog] = useState(false);
   const [inputStyleID, setInputStyleID] = useState("");
@@ -184,14 +194,23 @@ export const Settings = ({
 
         {/* Map style controll */}
         {mapProvider === "mapbox" ? (
-          <Box>
-            <ControlPanel
-              onChange={setMapStyle}
-              language={lang}
-              setLanguage={setLang}
-              mapStyle={mapStyle}
-            ></ControlPanel>
-          </Box>
+          <>
+            <Box>
+              <ControlPanel
+                onChange={setMapStyle}
+                language={lang}
+                setLanguage={setLang}
+                mapStyle={mapStyle}
+              ></ControlPanel>
+            </Box>
+
+            <ZoomSlider
+              zoomValue={zoom}
+              minZoomLevel={0}
+              maxZoomLevel={23}
+              onZoomChange={setZoom}
+            />
+          </>
         ) : (
           <></>
         )}

--- a/web-editor/src/component/Settings.jsx
+++ b/web-editor/src/component/Settings.jsx
@@ -2,11 +2,7 @@ import CodeIcon from "@mui/icons-material/Code";
 import KeyIcon from "@mui/icons-material/Key";
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
 import StyleIcon from "@mui/icons-material/Style";
-import {
-  IconButton,
-  InputAdornment,
-  Link
-} from "@mui/material";
+import { IconButton, InputAdornment, Link } from "@mui/material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";

--- a/web-editor/src/component/ZoomSlider.jsx
+++ b/web-editor/src/component/ZoomSlider.jsx
@@ -1,0 +1,69 @@
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import MuiInput from "@mui/material/Input";
+import Slider from "@mui/material/Slider";
+import Typography from "@mui/material/Typography";
+import * as React from "react";
+
+export const ZoomSlider = ({
+  zoomValue,
+  minZoomLevel,
+  maxZoomLevel,
+  onZoomChange,
+}) => {
+  const handleSliderChange = (_, newValue) => {
+    onZoomChange(newValue);
+  };
+
+  const handleInputChange = (event) => {
+    onZoomChange(event.target.value === "" ? "" : Number(event.target.value));
+  };
+
+  const handleBlur = () => {
+    if (zoomValue < minZoomLevel) {
+      onZoomChange(minZoomLevel);
+    } else if (zoomValue > maxZoomLevel) {
+      onZoomChange(maxZoomLevel);
+    }
+  };
+
+  return (
+    <Box>
+      <Typography id="input-slider" gutterBottom>
+        Zoom level
+      </Typography>
+      <Grid container spacing={2} alignItems="center">
+        <Grid item>
+          <ZoomInIcon />
+        </Grid>
+        <Grid item xs>
+          <Slider
+            size="small"
+            color="text"
+            value={typeof zoomValue === "number" ? zoomValue : 0}
+            min={minZoomLevel}
+            max={maxZoomLevel}
+            onChange={handleSliderChange}
+            aria-labelledby="input-slider"
+          />
+        </Grid>
+        <Grid item>
+          <MuiInput
+            value={zoomValue}
+            size="small"
+            onChange={handleInputChange}
+            onBlur={handleBlur}
+            inputProps={{
+              step: 1,
+              min: minZoomLevel,
+              max: maxZoomLevel,
+              type: "number",
+              "aria-labelledby": "input-slider",
+            }}
+          />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};

--- a/web-editor/src/screen/EditorScreen.jsx
+++ b/web-editor/src/screen/EditorScreen.jsx
@@ -182,6 +182,7 @@ export const EditorScreen = ({ mapProvider }) => {
             setMapStyle={setMapStyle}
             mapStyle={mapStyle}
             zoom={zoom}
+            setZoom={setZoom}
             lang={lang}
             pullKey={pullKey}
             apiKey={apiKey}


### PR DESCRIPTION
Adds a slider to the mapbox configuration panel, I believe having all the settings in one section is easier to understand, however, using the mouse wheel on the map will also continue to work to configure zoom.