### PR TITLE
feat: add speed overlay

### DIFF
--- a/web-editor/src/App.js
+++ b/web-editor/src/App.js
@@ -3,13 +3,14 @@ import Stack from "@mui/material/Stack";
 import { ThemeProvider } from "@mui/material/styles";
 import { useState } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import editorTheme from "./theme/editorTheme";
 import "./App.css";
 import { EditorAppbar } from "./component/Appbar";
 import { NavigationDrawer } from "./component/NavigationDrawer";
 import { EditorScreen } from "./screen/EditorScreen";
 import { Home } from "./screen/Home";
 import { SimpleTextEditScreen } from "./screen/SimpleTextEditorScreen";
+import SpeedEditor from "./screen/SpeedEditor";
+import editorTheme from "./theme/editorTheme";
 
 function App() {
   const [openDrawer, setOpenDrawer] = useState(false);
@@ -38,14 +39,13 @@ function App() {
                 path="/neighborhood"
                 element={<SimpleTextEditScreen />}
               />
-              <Route exact path="/speed" element={<SimpleTextEditScreen />} />
               <Route exact path="/clock" element={<SimpleTextEditScreen />} />
               <Route
                 exact
                 path="/temperature"
                 element={<SimpleTextEditScreen />}
               />
-              <Route exact path="/speed" element={<SimpleTextEditScreen />} />
+              <Route exact path="/speed" element={<SpeedEditor />} />
               <Route exact path="/heading" element={<SimpleTextEditScreen />} />
             </Routes>
           </Stack>

--- a/web-editor/src/component/PullKeyInput.jsx
+++ b/web-editor/src/component/PullKeyInput.jsx
@@ -1,0 +1,56 @@
+import KeyIcon from "@mui/icons-material/Key";
+import { Box, InputAdornment } from "@mui/material";
+import TextField from "@mui/material/TextField";
+import * as React from "react";
+
+const PULL_KEY_CHARSET = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+function validatePullkey(key) {
+  key = key.trim();
+  if (key.length !== 16) {
+    return false;
+  }
+  let checksum = 13;
+  for (let i = 0; i < 15; i++) {
+    const index = PULL_KEY_CHARSET.indexOf(key[i]);
+    checksum += index;
+  }
+  const checksumKey = PULL_KEY_CHARSET.charAt(
+    checksum % PULL_KEY_CHARSET.length
+  );
+  const lastChar = key[key.length - 1];
+  return checksumKey === lastChar;
+}
+
+function PullKeyInput({ pullKey, onKeyChange }) {
+  return (
+    <Box component="form" noValidate autoComplete="off">
+      <TextField
+        fullWidth
+        required
+        error={!validatePullkey(pullKey.value)}
+        id="standard-required"
+        label="Pull Key"
+        helperText="Pull Key from rtirl.com"
+        variant="standard"
+        value={pullKey.value}
+        onKeyPress={(e) => e.key === "Enter" && e.preventDefault()}
+        onChange={(e) => {
+          onKeyChange({
+            value: e.target.value,
+            valid: validatePullkey(e.target.value),
+          });
+        }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <KeyIcon />
+            </InputAdornment>
+          ),
+        }}
+      />
+    </Box>
+  );
+}
+
+export default PullKeyInput;

--- a/web-editor/src/component/SpeedUnitsToggle.jsx
+++ b/web-editor/src/component/SpeedUnitsToggle.jsx
@@ -1,0 +1,23 @@
+import { Box, Typography } from "@mui/material";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import * as React from "react";
+
+function SpeedUnitsToggle({ units, onUnitsChange }) {
+  return (
+    <Box>
+      <Typography gutterBottom>Units</Typography>
+      <ToggleButtonGroup
+        value={units}
+        exclusive
+        fullWidth
+        onChange={(_, selectedUnits) => onUnitsChange(selectedUnits)}
+      >
+        <ToggleButton value="mph">MPH</ToggleButton>
+        <ToggleButton value="kph">KPH</ToggleButton>
+      </ToggleButtonGroup>
+    </Box>
+  );
+}
+
+export default SpeedUnitsToggle;

--- a/web-editor/src/component/TextSettings.jsx
+++ b/web-editor/src/component/TextSettings.jsx
@@ -48,13 +48,8 @@ export const TextSettings = React.memo(({ textDivCSS, setTextDivCSS }) => {
   return (
     <Box
       style={{
-        width: "15vw",
-        padding: "16px",
+        height: "100%",
       }}
-      paddingLeft={4}
-      borderRight={1}
-      borderColor="primary.border"
-      backgroundColor="primary.main"
     >
       <Stack
         spacing={1}

--- a/web-editor/src/screen/SpeedEditor.jsx
+++ b/web-editor/src/screen/SpeedEditor.jsx
@@ -1,0 +1,149 @@
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import {
+  Box,
+  Grid,
+  IconButton,
+  InputAdornment,
+  TextField,
+} from "@mui/material";
+import List from "@mui/material/List";
+import Typography from "@mui/material/Typography";
+import * as React from "react";
+import { useState } from "react";
+import PullKeyInput from "../component/PullKeyInput";
+import SpeedUnitsToggle from "../component/SpeedUnitsToggle";
+import { TextSettings } from "../component/TextSettings";
+
+function SpeedEditor(props) {
+  const [pullKey, setPullKey] = useState({ value: "", valid: false });
+  const [units, setUnits] = useState("mph");
+  const [textDivCSS, setTextDivCSS] = useState({
+    textColor: "#94fe32",
+    fontFamily: "sans-serif",
+    rotation: 0,
+    fontSize: 30,
+    isBold: false,
+    isItalic: false,
+    opacity: 100,
+    backgroundColor: "#000000",
+    borderColor: "#ffffff",
+    borderWidth: 0,
+    padding: 0,
+    border_top_left_radius: 0,
+    border_top_right_radius: 0,
+    border_bottom_left_radius: 0,
+    border_bottom_right_radius: 0,
+    textAlign: "left",
+  });
+  const url = `https://overlays.rtirl.com/speed/${units}.html?key=${pullKey.value}`;
+
+  const textPreview = (text) => (
+    <Box height="75vh">
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          justifyContent: "center",
+          alignItems: "center",
+          display: "flex",
+        }}
+      >
+        <div
+          style={{
+            ...textDivCSS,
+            color: textDivCSS.textColor,
+            fontFamily: textDivCSS.fontFamily,
+            borderRadius: `${textDivCSS["border_top_left_radius"]}% ${textDivCSS["border_top_right_radius"]}% ${textDivCSS["border_bottom_right_radius"]}% ${textDivCSS["border_bottom_left_radius"]}%`,
+            fontSize: `${textDivCSS.fontSize}px`,
+            fontWeight: textDivCSS.isBold ? "bold" : "normal",
+            fontStyle: textDivCSS.isItalic ? "italic" : "normal",
+            transform: `rotate(${textDivCSS.rotation}deg)`,
+            opacity: textDivCSS.opacity / 100,
+            borderColor: textDivCSS.borderColor,
+            border: `${textDivCSS.borderWidth}px solid`,
+            justifyContent: textDivCSS.justifyContent,
+          }}
+        >
+          {text}
+        </div>
+      </div>
+    </Box>
+  );
+
+  const exportModule = (
+    <Box
+      style={{
+        marginTop: "8px",
+        padding: "8px",
+      }}
+      border={1}
+      borderColor="primary.border"
+      backgroundColor="primary.main"
+    >
+      <aside>
+        <h2> Speed Overlay URL </h2>
+        {pullKey.valid ? (
+          <TextField
+            readOnly
+            value={url}
+            fullWidth
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <IconButton
+                    onClick={() => {
+                      navigator.clipboard.writeText(url);
+                    }}
+                  >
+                    <ContentCopyIcon />
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          ></TextField>
+        ) : (
+          <Typography color="inherit">
+            Pull key is required for a generic overlay URL
+          </Typography>
+        )}
+      </aside>
+    </Box>
+  );
+  return (
+    <Grid container columns={{ xs: 1, md: 12 }} direction="row">
+      <Grid item xs={1} md={2.5}>
+        <Box
+          style={{
+            padding: "16px",
+            height: "100%",
+          }}
+          borderRight={1}
+          borderBottom={1}
+          borderColor="primary.border"
+          backgroundColor="primary.main"
+          textAlign="left"
+        >
+          <List>
+            <Typography variant="h6" component="div">
+              Settings
+            </Typography>
+            <PullKeyInput pullKey={pullKey} onKeyChange={setPullKey} />
+            <SpeedUnitsToggle units={units} onUnitsChange={setUnits} />
+            <TextSettings
+              textDivCSS={textDivCSS}
+              setTextDivCSS={setTextDivCSS}
+            />
+          </List>
+        </Box>
+      </Grid>
+      <Grid item xs={1} md={9.5} lg={12}>
+        <Box padding={1} paddingBottom={0}>
+          {textPreview(`1000 ${units.toUpperCase()}`)}
+          {exportModule}
+        </Box>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default SpeedEditor;


### PR DESCRIPTION
As it is, this PR breaks the other text pages, I'm submitting it just to validate if this could help us create more independent components.

This adds a new page for the speed overlay.

I also tried to make it "modular", this way, the `TextSettings` component only handles text styling and we can also reuse components such as `PullKeyInput` and probably the `textPreview`.