### PR TITLE
refactor: extract mapbox

### DIFF
--- a/web-editor/src/App.js
+++ b/web-editor/src/App.js
@@ -10,6 +10,7 @@ import ClockEditor from "./screen/ClockEditor";
 import { EditorScreen } from "./screen/EditorScreen";
 import HeadingEditor from "./screen/HeadingEditor";
 import { Home } from "./screen/Home";
+import MapboxEditor from "./screen/MapboxEditor";
 import { SimpleTextEditScreen } from "./screen/SimpleTextEditorScreen";
 import SpeedEditor from "./screen/SpeedEditor";
 import WeatherEditor from "./screen/WeatherEditor";
@@ -17,6 +18,7 @@ import editorTheme from "./theme/editorTheme";
 
 function App() {
   const [openDrawer, setOpenDrawer] = useState(false);
+  const [pullKey, setPullKey] = useState({ value: "", valid: false });
 
   return (
     <div className="App">
@@ -30,7 +32,12 @@ function App() {
               <Route
                 exact
                 path="/mapbox"
-                element={<EditorScreen mapProvider={"mapbox"} />}
+                element={
+                  <MapboxEditor
+                    pullKey={pullKey}
+                    onPullKeyChange={setPullKey}
+                  />
+                }
               />
               <Route
                 exact

--- a/web-editor/src/component/TextOverlayExportPanel.jsx
+++ b/web-editor/src/component/TextOverlayExportPanel.jsx
@@ -3,7 +3,7 @@ import { Box, IconButton, InputAdornment, TextField } from "@mui/material";
 import Typography from "@mui/material/Typography";
 import * as React from "react";
 
-function TextOverlayExportPanel({ overlayDescription, hasValidPullKey, url }) {
+function TextOverlayExportPanel({ overlayDescription, isExportable, url }) {
   return (
     <Box
       style={{
@@ -16,7 +16,7 @@ function TextOverlayExportPanel({ overlayDescription, hasValidPullKey, url }) {
     >
       <aside>
         <h2> {overlayDescription} </h2>
-        {hasValidPullKey ? (
+        {isExportable ? (
           <TextField
             readOnly
             value={url}
@@ -37,7 +37,7 @@ function TextOverlayExportPanel({ overlayDescription, hasValidPullKey, url }) {
           ></TextField>
         ) : (
           <Typography color="inherit">
-            Your pull key is required to generate the overlay URL.
+            Please correct all the errors in the settings section.
           </Typography>
         )}
       </aside>

--- a/web-editor/src/component/mapbox/MapboxContainer.jsx
+++ b/web-editor/src/component/mapbox/MapboxContainer.jsx
@@ -1,0 +1,62 @@
+import "mapbox-gl/dist/mapbox-gl.css";
+import * as React from "react";
+import MapGL from "react-map-gl";
+
+export default function MapboxContainer({
+  mapStyle,
+  apiKey,
+  canPreview,
+  zoom,
+  setZoom,
+  fullscreen,
+}) {
+  const mapRef = React.useRef();
+  const [viewState, setViewState] = React.useState({
+    longitude: -100,
+    latitude: 40,
+  });
+
+  React.useEffect(() => {
+    if (mapRef.current) {
+      mapRef.current.resize();
+    }
+  }, [fullscreen]);
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {canPreview ? (
+        <MapGL
+          style={{
+            height: fullscreen ? "100%" : "300px",
+            width: fullscreen ? "100%" : "300px",
+          }}
+          ref={mapRef}
+          zoom={zoom}
+          onZoom={(evt) => setZoom(evt.viewState.zoom)}
+          {...viewState}
+          mapStyle={mapStyle}
+          styleDiffing
+          onMove={(evt) =>
+            setViewState({
+              latitude: evt.viewState.latitude,
+              longitude: evt.viewState.longitude,
+            })
+          }
+          mapboxAccessToken={apiKey}
+        />
+      ) : (
+        <div>
+          <h1> Unable to preview, please verify the data provided </h1>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-editor/src/component/mapbox/MapboxSettings.jsx
+++ b/web-editor/src/component/mapbox/MapboxSettings.jsx
@@ -1,0 +1,164 @@
+import KeyIcon from "@mui/icons-material/Key";
+import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
+import StyleIcon from "@mui/icons-material/Style";
+import {
+  Checkbox,
+  FormControlLabel,
+  IconButton,
+  InputAdornment,
+} from "@mui/material";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { useState } from "react";
+import ControlPanel from "../ControlPanel";
+import PullKeyInput from "../PullKeyInput";
+import { StyleIDHelperDialog } from "../StyleIDHelperDialog";
+import { ZoomSlider } from "../ZoomSlider";
+
+export default function MapboxSettings({
+  pullKey,
+  onPullKeyChange,
+  styleId,
+  onStyleChange,
+  apiKey,
+  onApiKeyChange,
+  lang,
+  setLang,
+  mapStyle,
+  setMapStyle,
+  zoom,
+  setZoom,
+  fullscreen,
+  setFullscreen,
+}) {
+  const [openStyleIDDialog, setOpenStyleIDDialog] = useState(false);
+
+  return (
+    <Box
+      style={{
+        padding: "16px",
+        height: "100%",
+      }}
+      paddingLeft={4}
+      borderRight={1}
+      borderBottom={1}
+      borderColor="primary.border"
+      backgroundColor="primary.main"
+    >
+      <Stack
+        divider={<Divider orientation="vertical" flexItem />}
+        spacing={2}
+        textAlign="left"
+      >
+        <Typography variant="h6" component="div">
+          Settings
+        </Typography>
+
+        <PullKeyInput pullKey={pullKey} onKeyChange={onPullKeyChange} />
+
+        <Box component="form" noValidate autoComplete="off">
+          <TextField
+            fullWidth
+            required
+            id="standard-required"
+            label="API Key"
+            variant="standard"
+            value={apiKey}
+            error={!apiKey}
+            helperText={apiKey ? "" : "The API key is required"}
+            onKeyPress={(e) => e.key === "Enter" && e.preventDefault()}
+            onChange={(e) => onApiKeyChange(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <KeyIcon />
+                </InputAdornment>
+              ),
+            }}
+          />
+        </Box>
+
+        {/* Style Id form */}
+        <Box
+          component="form"
+          noValidate
+          autoComplete="off"
+          style={{ position: "relative" }}
+          onSubmit={(e) => {
+            e.preventDefault();
+          }}
+        >
+          <TextField
+            fullWidth
+            id="tf-style-id"
+            label="Style ID"
+            variant="standard"
+            value={styleId}
+            placeholder="Format: account/styleId"
+            error={!styleId}
+            helperText={styleId ? "" : "The style id is required"}
+            onSubmit={(e) => {
+              e.preventDefault();
+            }}
+            onChange={(e) => {
+              onStyleChange(e.target.value);
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <StyleIcon />
+                </InputAdornment>
+              ),
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton onClick={() => setOpenStyleIDDialog(true)}>
+                    <QuestionMarkIcon />
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+        </Box>
+
+        <Box>
+          <ControlPanel
+            onChange={setMapStyle}
+            language={lang}
+            setLanguage={setLang}
+            mapStyle={mapStyle}
+          ></ControlPanel>
+        </Box>
+
+        <Box>
+          <ZoomSlider
+            zoomValue={zoom}
+            minZoomLevel={0}
+            maxZoomLevel={23}
+            onZoomChange={setZoom}
+          />
+        </Box>
+
+        <Box>
+          <FormControlLabel
+            control={
+              <Checkbox
+                defaultChecked
+                value={fullscreen}
+                onChange={(event) => setFullscreen(event.target.checked)}
+              />
+            }
+            label="Fullscreen"
+          />
+        </Box>
+      </Stack>
+
+      <StyleIDHelperDialog
+        open={openStyleIDDialog}
+        setOpen={setOpenStyleIDDialog}
+      />
+    </Box>
+  );
+}

--- a/web-editor/src/screen/ClockEditor.jsx
+++ b/web-editor/src/screen/ClockEditor.jsx
@@ -186,7 +186,7 @@ function ClockEditor(props) {
           />
           <TextOverlayExportPanel
             overlayDescription="Clock Overlay URL"
-            hasValidPullKey={pullKey.valid}
+            isExportable={pullKey.valid}
             url={url}
           />
         </Box>

--- a/web-editor/src/screen/HeadingEditor.jsx
+++ b/web-editor/src/screen/HeadingEditor.jsx
@@ -65,7 +65,7 @@ function HeadingEditor(props) {
           />
           <TextOverlayExportPanel
             overlayDescription="Heading Overlay URL"
-            hasValidPullKey={pullKey.valid}
+            isExportable={pullKey.valid}
             url={url}
           />
         </Box>

--- a/web-editor/src/screen/MapboxEditor.jsx
+++ b/web-editor/src/screen/MapboxEditor.jsx
@@ -1,0 +1,80 @@
+import { Box, Grid, Stack } from "@mui/material";
+import * as React from "react";
+import { useEffect, useState } from "react";
+import MapboxContainer from "../component/mapbox/MapboxContainer";
+import MapboxSettings from "../component/mapbox/MapboxSettings";
+import { mapboxMapStyleJsonCache } from "../component/RightPanel";
+import TextOverlayExportPanel from "../component/TextOverlayExportPanel";
+
+export default function MapboxEditor({ pullKey, onPullKeyChange }) {
+  const [mapStyle, setMapStyle] = useState(null);
+  const [apiKey, setAPIKey] = useState(
+    "pk.eyJ1Ijoia2V2bW8zMTQiLCJhIjoiY2oyMDFlMGpsMDN3bTJ4bjR1MzRrbDFleCJ9.7XEB3HHBGr-N6ataUZh_6g"
+  );
+  const [styleId, setStyleID] = useState("mapbox/streets-v11");
+  const [zoom, setZoom] = useState(5);
+  const [fullscreen, setFullscreen] = useState(false);
+  const [lang, setLang] = useState("EN");
+  const [validStyle, setValidStyle] = useState(true);
+  const url = `https://overlays.rtirl.com/mapbox.html?key=${
+    pullKey.value
+  }&access_token=${apiKey}&style=${styleId}&zoom=${zoom}&lang=${lang}${
+    fullscreen ? "&fullscreen=1" : ""
+  }`;
+
+  useEffect(() => {
+    fetch(`https://api.mapbox.com/styles/v1/${styleId}?access_token=${apiKey}`)
+      .then((res) => {
+        res.status === 200 ? setValidStyle(true) : setValidStyle(false);
+        return res.json();
+      })
+      .then((res) => {
+        mapboxMapStyleJsonCache[styleId] = res;
+        setMapStyle(res);
+      });
+  }, [styleId, apiKey]);
+
+  return (
+    <Grid container columns={{ xs: 1, md: 12 }} direction="row">
+      <Grid item xs={1} md={2.5}>
+        <MapboxSettings
+          pullKey={pullKey}
+          onPullKeyChange={onPullKeyChange}
+          styleId={styleId}
+          onStyleChange={setStyleID}
+          apiKey={apiKey}
+          onApiKeyChange={setAPIKey}
+          lang={lang}
+          setLang={setLang}
+          mapStyle={mapStyle}
+          setMapStyle={setMapStyle}
+          zoom={zoom}
+          setZoom={setZoom}
+          fullscreen={fullscreen}
+          setFullscreen={setFullscreen}
+        />
+      </Grid>
+      <Grid item xs={1} md={9.5} lg={12}>
+        <Box padding={1} paddingBottom={0}>
+          <Box>
+            <Stack height="95vh" direction="column">
+              <MapboxContainer
+                canPreview={pullKey.valid && apiKey && styleId && validStyle}
+                zoom={zoom}
+                fullscreen={fullscreen}
+                setZoom={setZoom}
+                mapStyle={mapStyle}
+                apiKey={apiKey}
+              />
+              <TextOverlayExportPanel
+                overlayDescription="Mapbox Overlay URL"
+                isExportable={pullKey.valid && apiKey && styleId && validStyle}
+                url={url}
+              />
+            </Stack>
+          </Box>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+}

--- a/web-editor/src/screen/SpeedEditor.jsx
+++ b/web-editor/src/screen/SpeedEditor.jsx
@@ -55,7 +55,7 @@ function SpeedEditor(props) {
           />
           <TextOverlayExportPanel
             overlayDescription="Speed Overlay URL"
-            hasValidPullKey={pullKey.valid}
+            isExportable={pullKey.valid}
             url={url}
           />
         </Box>

--- a/web-editor/src/screen/WeatherEditor.jsx
+++ b/web-editor/src/screen/WeatherEditor.jsx
@@ -67,7 +67,7 @@ function WeatherEditor(props) {
           />
           <TextOverlayExportPanel
             overlayDescription="Weather Overlay URL"
-            hasValidPullKey={pullKey.valid}
+            isExportable={pullKey.valid}
             url={url}
           />
         </Box>


### PR DESCRIPTION
Extracts mapbox editor so that it is not tied to google maps configuration. Also removed the generic overlay and fixed some errors with style fetching.

Oh and I also started to pull up the state for the pullkey up so that it is stored even after you change overlay, ill add separate prs for the refactor in the other editors.

Ill send a separate PR to clean up google maps.