### PR TITLE
style: update checked checkbox color

### DIFF
--- a/web-editor/src/theme/editorTheme.jsx
+++ b/web-editor/src/theme/editorTheme.jsx
@@ -89,6 +89,16 @@ const editorTheme = createTheme({
         },
       },
     },
+    MuiCheckbox: {
+      styleOverrides: {
+        colorPrimary: {
+          color: colors.text.main,
+          "&.Mui-checked": {
+            color: colors.text.main,
+          },
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
Checked checkboxes use text color now instead of the primary color which made it impossible to see.