### PR TITLE
fix: prevent text style reset by isolating font state

### DIFF
--- a/web-editor/src/component/TextSettings.jsx
+++ b/web-editor/src/component/TextSettings.jsx
@@ -17,7 +17,7 @@ import {
 import Box from "@mui/material/Box";
 import Slider from "@mui/material/Slider";
 import Stack from "@mui/material/Stack";
-import React from "react";
+import React, { useEffect } from "react";
 import ColorPickerToggle from "./ColorPickerToggle";
 import { CopyIconTextField } from "./CopyIconTextField";
 import FontPicker from "./FontPicker";
@@ -37,6 +37,11 @@ export const TextSettings = React.memo(({ textDivCSS, setTextDivCSS }) => {
     `border-radius: ${textDivCSS.border_top_left_radius}% ${textDivCSS.border_top_right_radius}% ${textDivCSS.border_bottom_right_radius}% ${textDivCSS.border_bottom_left_radius}%`,
     `padding: ${textDivCSS.padding}px`,
   ].join(";\n");
+  const [fontFamily, setFontFamily] = React.useState(textDivCSS.fontFamily);
+
+  useEffect(() => {
+    setTextDivCSS({ ...textDivCSS, fontFamily });
+  }, [fontFamily, textDivCSS, setTextDivCSS]);
 
   const css = `@import url('https://fonts.googleapis.com/css2?family=${textDivCSS.fontFamily}&display=swap');
   body {\n${properties}\n}`;
@@ -97,14 +102,9 @@ export const TextSettings = React.memo(({ textDivCSS, setTextDivCSS }) => {
             </Box>
           </Stack>
           <FontPicker
-            apiKey="AIzaSyCNxjzD_cGkwlE-6OgL3JsAJuCcnh6SWG8"
-            activeFontFamily={textDivCSS.fontFamily}
-            onChange={(nextFont) =>
-              setTextDivCSS({
-                ...textDivCSS,
-                fontFamily: nextFont.family,
-              })
-            }
+            apiKey="AIzaSyD2LLAAifY_CrNiQonhmI9d3o3wlQH9sis"
+            activeFontFamily={fontFamily}
+            onChange={(nextFont) => setFontFamily(nextFont.family)}
           />
 
           <Stack direction="row">

--- a/web-editor/src/component/TextSettings.jsx
+++ b/web-editor/src/component/TextSettings.jsx
@@ -102,7 +102,7 @@ export const TextSettings = React.memo(({ textDivCSS, setTextDivCSS }) => {
             </Box>
           </Stack>
           <FontPicker
-            apiKey="AIzaSyD2LLAAifY_CrNiQonhmI9d3o3wlQH9sis"
+            apiKey="AIzaSyCNxjzD_cGkwlE-6OgL3JsAJuCcnh6SWG8"
             activeFontFamily={fontFamily}
             onChange={(nextFont) => setFontFamily(nextFont.family)}
           />


### PR DESCRIPTION
I am not sure why the reset happened? Might be related with the callback being sent to the underlying FontManager and maybe it has "old" text style?