### PR TITLE
fix: don't update text if the string undefined is present

### DIFF
--- a/public/neighborhood.html
+++ b/public/neighborhood.html
@@ -58,10 +58,13 @@
                   feature.place_type.includes(param)
                 );
               }
-              document.getElementById("text").innerText = wrappedEval(
+              var result = wrappedEval(
                 "`" + format + "`",
                 context
               );
+              if (!result.includes("undefined")) {
+                document.getElementById("text").innerText = result; 
+              }
             });
         }
       });


### PR DESCRIPTION
This isn't a perfect fix, ideally we should check the resultant variables instead of the string, but that's not so easy to do with eval.