### PR TITLE
style: update sidebar for mapbox overlay

### DIFF
--- a/web-editor/src/component/ExclusiveToggle.jsx
+++ b/web-editor/src/component/ExclusiveToggle.jsx
@@ -5,7 +5,7 @@ import * as React from "react";
 
 function ExclusiveToggle({ name, selectedOption, onOptionChange, options }) {
   return (
-    <Box bgcolor="black" sx={{ marginTop: "3%", padding: "4%" }}>
+    <Box bgcolor="black" sx={{ marginTop: "1%", padding: "4%" }}>
       <Typography gutterBottom>{name}</Typography>
       <ToggleButtonGroup
         value={selectedOption}

--- a/web-editor/src/component/ZoomSlider.jsx
+++ b/web-editor/src/component/ZoomSlider.jsx
@@ -30,7 +30,11 @@ export const ZoomSlider = ({
 
   return (
     <Box bgcolor="black">
-      <Typography id="input-slider" gutterBottom sx={{ paddingLeft: "28px", paddingTop: "10px" }}>
+      <Typography
+        id="input-slider"
+        gutterBottom
+        sx={{ paddingLeft: "28px", paddingTop: "10px" }}
+      >
         Zoom level
       </Typography>
       <Grid container spacing={2}>
@@ -49,11 +53,11 @@ export const ZoomSlider = ({
             sx={{
               paddingLeft: "6%",
               paddingBottom: "2%",
-              width:"70%"
+              width: "70%",
             }}
           />
         </Grid>
-        <Grid item sx={{paddingBottom:"8px", paddingRight:"20px"}}>
+        <Grid item sx={{ paddingBottom: "8px", paddingRight: "20px" }}>
           <MuiInput
             value={zoomValue}
             size="small"

--- a/web-editor/src/component/ZoomSlider.jsx
+++ b/web-editor/src/component/ZoomSlider.jsx
@@ -29,11 +29,11 @@ export const ZoomSlider = ({
   };
 
   return (
-    <Box>
-      <Typography id="input-slider" gutterBottom>
+    <Box bgcolor="black">
+      <Typography id="input-slider" gutterBottom sx={{ paddingLeft: "28px", paddingTop: "10px" }}>
         Zoom level
       </Typography>
-      <Grid container spacing={2} alignItems="center">
+      <Grid container spacing={2}>
         <Grid item>
           <ZoomInIcon />
         </Grid>
@@ -46,9 +46,14 @@ export const ZoomSlider = ({
             max={maxZoomLevel}
             onChange={handleSliderChange}
             aria-labelledby="input-slider"
+            sx={{
+              paddingLeft: "6%",
+              paddingBottom: "2%",
+              width:"70%"
+            }}
           />
         </Grid>
-        <Grid item>
+        <Grid item sx={{paddingBottom:"8px", paddingRight:"20px"}}>
           <MuiInput
             value={zoomValue}
             size="small"

--- a/web-editor/src/component/mapbox/MapboxSettings.jsx
+++ b/web-editor/src/component/mapbox/MapboxSettings.jsx
@@ -23,6 +23,7 @@ import PullKeyInput from "../PullKeyInput";
 import { ZoomSlider } from "../ZoomSlider";
 import { AttributionDialog } from "./AttributionDialog";
 import { StyleIDHelperDialog } from "./StyleIDHelperDialog";
+import OverlayExportPanel from "../OverlayExportPanel";
 
 export default function MapboxSettings({
   pullKey,
@@ -33,6 +34,8 @@ export default function MapboxSettings({
   onApiKeyChange,
   lang,
   setLang,
+  validStyle,
+  setValidStyle,
   zoom,
   setZoom,
   fullscreen,
@@ -50,6 +53,20 @@ export default function MapboxSettings({
     { name: "Leaflet", value: "leaflet" },
     { name: "Mapbox GL", value: "mapbox" },
   ];
+  const indicatorStyleB64 = encodeURIComponent(
+    window.btoa(JSON.stringify(indicatorStyle))
+  );
+  const url = `https://overlays.rtirl.com/${mapLibrary}.html?key=${
+    pullKey.value
+  }&access_token=${apiKey}&style=${styleId}&zoom=${zoom}&lang=${lang}${
+    fullscreen ? "&fullscreen=1" : ""
+  }&attribution=${attribution ? "1" : "0"}&indicatorStyle=${indicatorStyleB64}`;
+  const iFrameTag = `<iframe height="100%" width="100%" frameborder="0" 
+  src="https://overlays.rtirl.com/compat.html?key=${
+    pullKey.value
+  }&access_token=${apiKey}&style=${styleId}&attribution=${
+    attribution ? "1" : "0"
+  }"> </iframe>`;
 
   return (
     <Box
@@ -66,11 +83,19 @@ export default function MapboxSettings({
         spacing={1}
         textAlign="left"
       >
-
-
         <PullKeyInput pullKey={pullKey} onKeyChange={onPullKeyChange} />
 
-        <Box component="form" noValidate autoComplete="off" bgcolor="black" sx={{paddingLeft: "24px", paddingTop: "10px", paddingBottom:"15px"}}>
+        <Box
+          component="form"
+          noValidate
+          autoComplete="off"
+          bgcolor="black"
+          sx={{
+            paddingLeft: "24px",
+            paddingTop: "10px",
+            paddingBottom: "15px",
+          }}
+        >
           <TextField
             fullWidth
             required
@@ -83,7 +108,7 @@ export default function MapboxSettings({
             onKeyPress={(e) => e.key === "Enter" && e.preventDefault()}
             onChange={(e) => onApiKeyChange(e.target.value)}
             sx={{
-              width:"95%"
+              width: "95%",
             }}
             InputProps={{
               startAdornment: (
@@ -92,6 +117,20 @@ export default function MapboxSettings({
                 </InputAdornment>
               ),
             }}
+          />
+        </Box>
+
+        <Box bgcolor="black" sx={{ marginTop: "12px" }}>
+          <Typography sx={{ paddingLeft: "24px", paddingTop: "10px" }}>
+            Export
+          </Typography>
+          <OverlayExportPanel
+            overlayDescription="Mapbox Overlay URL"
+            isExportable={pullKey.valid && apiKey && styleId && validStyle}
+            url={url}
+            streamElementExportable={true}
+            iFrameTag={iFrameTag}
+            type="mapbox_overlay"
           />
         </Box>
 
@@ -105,7 +144,11 @@ export default function MapboxSettings({
             e.preventDefault();
           }}
           bgcolor="black"
-          sx={{paddingLeft: "24px", paddingTop: "10px", paddingBottom:"15px"}}
+          sx={{
+            paddingLeft: "24px",
+            paddingTop: "10px",
+            paddingBottom: "15px",
+          }}
         >
           <TextField
             fullWidth
@@ -137,13 +180,19 @@ export default function MapboxSettings({
               ),
             }}
             sx={{
-              width:"95%"
+              width: "95%",
             }}
           />
         </Box>
 
-        <Box bgcolor="black" sx={{marginTop: "12px" }}>
-          <InputLabel id="select-language-label" sx={{ paddingLeft: "24px", paddingTop: "10px" }}> Language </InputLabel>
+        <Box bgcolor="black" sx={{ marginTop: "12px" }}>
+          <InputLabel
+            id="select-language-label"
+            sx={{ paddingLeft: "24px", paddingTop: "10px" }}
+          >
+            {" "}
+            Language{" "}
+          </InputLabel>
           <CountryPicker
             lang={lang}
             setLang={setLang}
@@ -175,7 +224,7 @@ export default function MapboxSettings({
           />
         </Box>
 
-        <Box bgcolor="black" sx={{marginTop:"12px"}}>
+        <Box bgcolor="black" sx={{ marginTop: "12px" }}>
           <FormControlLabel
             control={
               <Checkbox
@@ -184,11 +233,15 @@ export default function MapboxSettings({
               />
             }
             label="Fullscreen"
-            sx={{paddingLeft: "24px", paddingTop: "5px", paddingBottom:"5px"}}
+            sx={{
+              paddingLeft: "24px",
+              paddingTop: "5px",
+              paddingBottom: "5px",
+            }}
           />
         </Box>
 
-        <Box bgcolor="black" sx={{padding:"15px"}}>
+        <Box bgcolor="black" sx={{ padding: "15px" }}>
           <IndicatorSetting
             indicatorStyle={indicatorStyle}
             setIndicatorStyle={setIndicatorStyle}
@@ -203,17 +256,20 @@ export default function MapboxSettings({
             onOptionChange={onMapLibraryChange}
           />
           <Box bgcolor="black">
-          <Typography sx={{ p: 1 }}>
-            <InfoIcon style={{ verticalAlign: "middle" }} />
-            While both libraries use Mapbox tiles, Leaflet is more compatible
-            with streaming tools such as Prism Live, StreamLabs and
-            StreamElements.
-          </Typography>
+            <Typography sx={{ p: 1 }}>
+              <InfoIcon style={{ verticalAlign: "middle" }} />
+              While both libraries use Mapbox tiles, Leaflet is more compatible
+              with streaming tools such as Prism Live, StreamLabs and
+              StreamElements.
+            </Typography>
           </Box>
         </Box>
 
         {mapLibrary === "leaflet" && (
-          <Box bgcolor="black" sx={{ display: "flex", justifyContent: "space-between" }}>
+          <Box
+            bgcolor="black"
+            sx={{ display: "flex", justifyContent: "space-between" }}
+          >
             <FormControlLabel
               control={
                 <Checkbox

--- a/web-editor/src/component/mapbox/MapboxSettings.jsx
+++ b/web-editor/src/component/mapbox/MapboxSettings.jsx
@@ -54,10 +54,8 @@ export default function MapboxSettings({
   return (
     <Box
       style={{
-        padding: "16px",
-        height: "100%",
+        height: "max-content",
       }}
-      paddingLeft={4}
       borderRight={1}
       borderBottom={1}
       borderColor="primary.border"
@@ -65,16 +63,14 @@ export default function MapboxSettings({
     >
       <Stack
         divider={<Divider orientation="vertical" flexItem />}
-        spacing={2}
+        spacing={1}
         textAlign="left"
       >
-        <Typography variant="h6" component="div">
-          Settings
-        </Typography>
+
 
         <PullKeyInput pullKey={pullKey} onKeyChange={onPullKeyChange} />
 
-        <Box component="form" noValidate autoComplete="off">
+        <Box component="form" noValidate autoComplete="off" bgcolor="black" sx={{paddingLeft: "24px", paddingTop: "10px", paddingBottom:"15px"}}>
           <TextField
             fullWidth
             required
@@ -86,6 +82,9 @@ export default function MapboxSettings({
             helperText={apiKey ? "" : "The API key is required"}
             onKeyPress={(e) => e.key === "Enter" && e.preventDefault()}
             onChange={(e) => onApiKeyChange(e.target.value)}
+            sx={{
+              width:"95%"
+            }}
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
@@ -105,6 +104,8 @@ export default function MapboxSettings({
           onSubmit={(e) => {
             e.preventDefault();
           }}
+          bgcolor="black"
+          sx={{paddingLeft: "24px", paddingTop: "10px", paddingBottom:"15px"}}
         >
           <TextField
             fullWidth
@@ -135,11 +136,14 @@ export default function MapboxSettings({
                 </InputAdornment>
               ),
             }}
+            sx={{
+              width:"95%"
+            }}
           />
         </Box>
 
-        <Box>
-          <InputLabel id="select-language-label"> Language </InputLabel>
+        <Box bgcolor="black" sx={{marginTop: "12px" }}>
+          <InputLabel id="select-language-label" sx={{ paddingLeft: "24px", paddingTop: "10px" }}> Language </InputLabel>
           <CountryPicker
             lang={lang}
             setLang={setLang}
@@ -171,7 +175,7 @@ export default function MapboxSettings({
           />
         </Box>
 
-        <Box>
+        <Box bgcolor="black" sx={{marginTop:"12px"}}>
           <FormControlLabel
             control={
               <Checkbox
@@ -180,10 +184,11 @@ export default function MapboxSettings({
               />
             }
             label="Fullscreen"
+            sx={{paddingLeft: "24px", paddingTop: "5px", paddingBottom:"5px"}}
           />
         </Box>
 
-        <Box>
+        <Box bgcolor="black" sx={{padding:"15px"}}>
           <IndicatorSetting
             indicatorStyle={indicatorStyle}
             setIndicatorStyle={setIndicatorStyle}
@@ -197,17 +202,18 @@ export default function MapboxSettings({
             options={libraries}
             onOptionChange={onMapLibraryChange}
           />
-
+          <Box bgcolor="black">
           <Typography sx={{ p: 1 }}>
             <InfoIcon style={{ verticalAlign: "middle" }} />
             While both libraries use Mapbox tiles, Leaflet is more compatible
             with streaming tools such as Prism Live, StreamLabs and
             StreamElements.
           </Typography>
+          </Box>
         </Box>
 
         {mapLibrary === "leaflet" && (
-          <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+          <Box bgcolor="black" sx={{ display: "flex", justifyContent: "space-between" }}>
             <FormControlLabel
               control={
                 <Checkbox

--- a/web-editor/src/screen/MapboxEditor.jsx
+++ b/web-editor/src/screen/MapboxEditor.jsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { useEffect, useState } from "react";
 import MapboxContainer from "../component/mapbox/MapboxContainer";
 import MapboxSettings from "../component/mapbox/MapboxSettings";
-import OverlayExportPanel from "../component/OverlayExportPanel";
 
 const mapboxMapStyleJsonCache = [];
 

--- a/web-editor/src/screen/MapboxEditor.jsx
+++ b/web-editor/src/screen/MapboxEditor.jsx
@@ -25,21 +25,6 @@ export default function MapboxEditor({
   const [lang, setLang] = useState("en");
   const [validStyle, setValidStyle] = useState(true);
 
-  const indicatorStyleB64 = encodeURIComponent(
-    window.btoa(JSON.stringify(indicatorStyle))
-  );
-  const url = `https://overlays.rtirl.com/${mapLibrary}.html?key=${
-    pullKey.value
-  }&access_token=${apiKey}&style=${styleId}&zoom=${zoom}&lang=${lang}${
-    fullscreen ? "&fullscreen=1" : ""
-  }&attribution=${attribution ? "1" : "0"}&indicatorStyle=${indicatorStyleB64}`;
-  const iFrameTag = `<iframe height="100%" width="100%" frameborder="0" 
-  src="https://overlays.rtirl.com/compat.html?key=${
-    pullKey.value
-  }&access_token=${apiKey}&style=${styleId}&attribution=${
-    attribution ? "1" : "0"
-  }"> </iframe>`;
-
   useEffect(() => {
     fetch(`https://api.mapbox.com/styles/v1/${styleId}?access_token=${apiKey}`)
       .then((res) => {
@@ -64,6 +49,8 @@ export default function MapboxEditor({
           onApiKeyChange={setAPIKey}
           lang={lang}
           setLang={setLang}
+          validStyle={validStyle}
+          setValidStyle={setValidStyle}
           zoom={zoom}
           setZoom={setZoom}
           fullscreen={fullscreen}
@@ -88,14 +75,6 @@ export default function MapboxEditor({
                 mapStyle={mapStyle}
                 apiKey={apiKey}
                 indicatorStyle={indicatorStyle}
-              />
-              <OverlayExportPanel
-                overlayDescription="Mapbox Overlay URL"
-                isExportable={pullKey.valid && apiKey && styleId && validStyle}
-                url={url}
-                streamElementExportable={true}
-                iFrameTag={iFrameTag}
-                type="mapbox_overlay"
               />
             </Stack>
           </Box>


### PR DESCRIPTION
I'm unsure whether or not the map should occupy the available space left behind from moving the overlay export panel to the sidebar

closes #209