### PR TITLE
feat: add npm badges to API README

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,5 +1,8 @@
 # RealtimeIRL Client API
 
+![npm](https://img.shields.io/npm/v/@rtirl/api)
+![npm](https://img.shields.io/npm/dw/@rtirl/api)
+
 An API to access RealtimeIRL data.
 
 ## Installation


### PR DESCRIPTION
Adds npm version and download badges to the `api/README.md` for the `@rtirl/api` package.

- **Inserts npm version badge** to display the current version of the `@rtirl/api` package directly below the top header in the README.
- **Adds npm downloads badge** to show the download stats for the `@rtirl/api` package, enhancing visibility of the package's usage and popularity.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtirl-obs?shareId=2cc209eb-529c-4500-81cd-914f03dcb7f8).