### PR TITLE
feat: add cycling cadence editor

### DIFF
--- a/web-editor/src/App.js
+++ b/web-editor/src/App.js
@@ -21,6 +21,7 @@ import NeighborhoodEditor from "./screen/NeighborhoodEditor";
 import SpeedEditor from "./screen/SpeedEditor";
 import WeatherEditor from "./screen/WeatherEditor";
 import HeartRateEditor from "./screen/HeartRateEditor";
+import CyclingCadenceEditor from "./screen/CyclingCadenceEditor";
 import editorTheme from "./theme/editorTheme";
 
 function useQuery() {
@@ -180,6 +181,18 @@ function App() {
               path="/heart_rate"
               element={
                 <HeartRateEditor
+                  pullKey={pullKey}
+                  onPullKeyChange={setPullKey}
+                  textStyle={textStyle}
+                  onTextStyleChange={setTextStyle}
+                />
+              }
+            />
+            <Route
+              exact
+              path="/cycling_cadence"
+              element={
+                <CyclingCadenceEditor
                   pullKey={pullKey}
                   onPullKeyChange={setPullKey}
                   textStyle={textStyle}

--- a/web-editor/src/screen/CyclingCadenceEditor.jsx
+++ b/web-editor/src/screen/CyclingCadenceEditor.jsx
@@ -1,0 +1,68 @@
+import { Box, Grid, Typography } from "@mui/material";
+import { useState } from "react";
+import OverlayExportPanel from "../component/OverlayExportPanel";
+import PullKeyInput from "../component/PullKeyInput";
+import TextOverlayPreview from "../component/TextOverlayPreview";
+import { TextSettings } from "../component/TextSettings";
+import { scrollbarStyles } from "../theme/editorTheme";
+
+function CyclingCadenceEditor({
+  pullKey,
+  onPullKeyChange,
+  textStyle,
+  onTextStyleChange,
+}) {
+  const url = `https://overlays.rtirl.com/cycling_cadence/rpm.html?key=${pullKey.value}`;
+
+  return (
+    <Grid container columns={{ xs: 1, md: 12 }} direction="row">
+      <Grid
+        item
+        xs={1}
+        md={2.5}
+        sx={{
+          overflow: "auto",
+          height: "100vh",
+          ...scrollbarStyles,
+        }}
+      >
+        <Box
+          style={{
+            height: "max-content",
+          }}
+          borderRight={1}
+          borderBottom={1}
+          borderColor="primary.border"
+          backgroundColor="primary.main"
+          textAlign="left"
+        >
+          <PullKeyInput pullKey={pullKey} onKeyChange={onPullKeyChange} />
+
+          <Box bgcolor="black" sx={{ marginTop: "12px" }}>
+            <Typography sx={{ paddingLeft: "24px", paddingTop: "10px" }}>
+              Export
+            </Typography>
+            <OverlayExportPanel
+              overlayDescription="Cycling Cadence Overlay URL"
+              isExportable={pullKey.valid}
+              url={url}
+              textDivCSS={textStyle}
+              type="cycling_cadence_overlay"
+            />
+          </Box>
+          <TextSettings
+            textDivCSS={textStyle}
+            setTextDivCSS={onTextStyleChange}
+          />
+        </Box>
+      </Grid>
+      <Grid item xs={1} md={9.5} lg={12}>
+        <Box padding={1} paddingBottom={0}>
+          <TextOverlayPreview text={`75 rpm`} textDivCSS={textStyle} />
+        </Box>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default CyclingCadenceEditor;

--- a/web-editor/src/screen/CyclingCadenceEditor.jsx
+++ b/web-editor/src/screen/CyclingCadenceEditor.jsx
@@ -1,5 +1,4 @@
 import { Box, Grid, Typography } from "@mui/material";
-import { useState } from "react";
 import OverlayExportPanel from "../component/OverlayExportPanel";
 import PullKeyInput from "../component/PullKeyInput";
 import TextOverlayPreview from "../component/TextOverlayPreview";

--- a/web-editor/src/screen/Home.jsx
+++ b/web-editor/src/screen/Home.jsx
@@ -87,6 +87,11 @@ const pages = [
     route: "/heart_rate",
     text: "72 bpm",
   },
+  {
+    name: "Cycling Cadence",
+    route: "/cycling_cadence",
+    text: "75 rpm",
+  },
 ];
 
 export const Home = (props) => {


### PR DESCRIPTION
Add a new editor for cycling cadence in the web editor.

* **App.js**
  - Add a new route for the cycling cadence editor.
  - Import `CyclingCadenceEditor` component.
* **CyclingCadenceEditor.jsx**
  - Create a new component `CyclingCadenceEditor` to handle the cycling cadence editor functionality.
  - Include necessary imports and state management.
  - Add input fields for pull key and other settings.
  - Add a preview section for the cycling cadence overlay.
* **Home.jsx**
  - Add the cycling cadence editor to the home screen.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtirl-obs?shareId=5cb73d10-ceeb-475a-8266-f3faae99aa64).