### PR TITLE
fix: update speed overlay references

### DIFF
--- a/public/speed/kmh.html
+++ b/public/speed/kmh.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/@rtirl/api@latest/lib/index.min.js"></script>
+    <script defer src="../css.js"></script>
+  </head>
+  <body>
+    <div id="text"><span id="speed">0</span> km/h</div>
+    <script>
+      const pullKey = new URLSearchParams(window.location.search).get("key");
+      var timer;
+      RealtimeIRL.forPullKey(pullKey).addSpeedListener(function (speed) {
+
+        clearTimeout(timer); //don't reset to 0 if moving
+
+        const speedInKmh = (speed * 3.6) | 0;
+        document.getElementById("speed").innerText = speedInKmh > 0 ? speedInKmh : 0;
+
+        timer = setTimeout(() => { //reset to 0 if not moving for 30 sec
+          document.getElementById("speed").innerText = 0;
+        }, 30000);
+
+      });
+    </script>
+  </body>
+</html>

--- a/web-editor/src/screen/SpeedEditor.jsx
+++ b/web-editor/src/screen/SpeedEditor.jsx
@@ -20,6 +20,21 @@ function SpeedEditor({
   onTextStyleChange,
 }) {
   const [units, setUnits] = useState("mph");
+
+  // Function to get the display format for each unit type
+  const getDisplayUnits = (unitType) => {
+    switch (unitType) {
+      case "mph":
+        return "mph";
+      case "kph":
+        return "kmh";
+      case "minperkm":
+        return "/km";
+      default:
+        return unitType;
+    }
+  };
+
   const url = `https://overlays.rtirl.com/speed/${units}.html?key=${pullKey.value}`;
 
   return (
@@ -72,7 +87,7 @@ function SpeedEditor({
       <Grid item xs={1} md={9.5} lg={12}>
         <Box padding={1} paddingBottom={0}>
           <TextOverlayPreview
-            text={`1000 ${units.toUpperCase()}`}
+            text={`1000 ${getDisplayUnits(units)}`}
             textDivCSS={textStyle}
           />
         </Box>

--- a/web-editor/src/screen/SpeedEditor.jsx
+++ b/web-editor/src/screen/SpeedEditor.jsx
@@ -21,7 +21,6 @@ function SpeedEditor({
 }) {
   const [units, setUnits] = useState("mph");
 
-  // Function to get the display format for each unit type
   const getDisplayUnits = (unitType) => {
     switch (unitType) {
       case "mph":

--- a/web-editor/src/screen/SpeedEditor.jsx
+++ b/web-editor/src/screen/SpeedEditor.jsx
@@ -9,7 +9,7 @@ import { scrollbarStyles } from "../theme/editorTheme";
 
 const speedOptions = [
   { name: "MPH", value: "mph" },
-  { name: "KMH", value: "kmh" },
+  { name: "KMH", value: "kph" },
   { name: "MIN/KM", value: "minperkm" },
 ];
 

--- a/web-editor/src/screen/SpeedEditor.jsx
+++ b/web-editor/src/screen/SpeedEditor.jsx
@@ -9,7 +9,7 @@ import { scrollbarStyles } from "../theme/editorTheme";
 
 const speedOptions = [
   { name: "MPH", value: "mph" },
-  { name: "KMH", value: "kph" },
+  { name: "KMH", value: "kmh" },
   { name: "MIN/KM", value: "minperkm" },
 ];
 
@@ -20,19 +20,6 @@ function SpeedEditor({
   onTextStyleChange,
 }) {
   const [units, setUnits] = useState("mph");
-
-  const getDisplayUnits = (unitType) => {
-    switch (unitType) {
-      case "mph":
-        return "mph";
-      case "kph":
-        return "kmh";
-      case "minperkm":
-        return "/km";
-      default:
-        return unitType;
-    }
-  };
 
   const url = `https://overlays.rtirl.com/speed/${units}.html?key=${pullKey.value}`;
 
@@ -86,7 +73,7 @@ function SpeedEditor({
       <Grid item xs={1} md={9.5} lg={12}>
         <Box padding={1} paddingBottom={0}>
           <TextOverlayPreview
-            text={`1000 ${getDisplayUnits(units)}`}
+            text={`1000 ${units.toUpperCase()}`}
             textDivCSS={textStyle}
           />
         </Box>


### PR DESCRIPTION
This is a weird fix.

- Currently our 'preview' doesn't match the overlay, this fixes that.
- Fixes reference to non existing /kmh.html overlay.

Im not convinced about this one and made it in a rush so please suggest.

Also, another simpler alternative, *which doesn't fix the first item mentioned*, is to just make a copy of the kph.html file but name it kmh.html. This makes it 'backwards' compatible with those already using the overlay.